### PR TITLE
Rework swap package to receive size of the swap.

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -10,7 +10,7 @@ if NODE_CONFIG['enabled']
   if ENV['STAGE'] == 'setup'
     policy :setup, roles: :setup do
       requires :setup_system, deployer_user: NODE_CONFIG['deployer_user']
-      requires :swap, deployer_user: NODE_CONFIG['deployer_user'] unless ENV['NO_SWAP']
+      requires :swap, deployer_user: NODE_CONFIG['deployer_user'], swap_size: NODE_CONFIG['swap'] unless ENV['NO_SWAP']
     end
 
     deployment do

--- a/lib/swap.rb
+++ b/lib/swap.rb
@@ -3,8 +3,8 @@ module Sprinkle
     module Swap
       Sprinkle::Verify.register(Sprinkle::Verifiers::Swap)
 
-      def has_swap_memory
-        @commands << "[ \"$(grep -ie 'SwapTotal' /proc/meminfo | cut -d' ' -f2- | tr -d '[A-Z][a-z] ')\" -gt 0 ] && echo true"
+      def has_swap_memory(size)
+        @commands << "[ $(free -g | grep -oP '(Swap:)(\\s*)(\\d)' | grep -Po '\\d') -eq #{size} ]"
       end
     end
   end

--- a/nodes.yml.example
+++ b/nodes.yml.example
@@ -1,6 +1,7 @@
 vagrant:
   enabled: true
   ip: 192.168.100.33
+  swap: 2
   packages:
     utils: ~
     nginx: ~

--- a/packages/swap.rb
+++ b/packages/swap.rb
@@ -1,18 +1,16 @@
 package :swap do
-  block_size_mb = 128
-  block_count = 16 # 2Gb swap
+  swap_size = opts[:swap_size] || 2
   swap_fstab = '/swapfile   none    swap    sw    0   0'
 
-  runner "sudo dd if=/dev/zero of=/swapfile bs=#{block_size_mb}M count=#{block_count}"
+  runner "fallocate -l #{swap_size}G /swapfile"
   runner 'sudo chmod 600 /swapfile'
   runner 'sudo mkswap /swapfile'
   runner 'sudo swapon /swapfile'
-  runner 'sudo swapon -s'
   runner "sh -c \"echo '#{swap_fstab}' >> /etc/fstab\""
 
   verify do
     file_contains '/etc/fstab', swap_fstab
     has_file '/swapfile'
-    has_swap_memory
+    has_swap_memory(swap_size)
   end
 end


### PR DESCRIPTION
Now swap package can receive as parameter in node config file size of the swap.
The default size that the swap package will use in case of absence `swap` parameter in nodes files is 2GB. This size has been chosen for backward compatibility. If you don't want to install swap at all you have to use special ENV variable for this.

The swap parameter receives size in GB.

Also this commit has next improvements:
  - Using fallocate instead of `dd` for file creation. It works much faster.
  - Modify verification process to check summarized size of the swap on
  a machine.